### PR TITLE
feat(warp): add Warp install target (v0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,34 @@ bunx @every-env/compound-plugin install compound-engineering --to gemini
 bunx @every-env/compound-plugin install compound-engineering --to kiro
 ```
 
+### Warp (experimental, fork only)
+
+This fork ([metalingusman/compound-engineering-plugin](https://github.com/metalingusman/compound-engineering-plugin)) adds a `--to warp` target that installs the Compound Engineering skills into Warp's `.warp/skills/` directory and merges a Compound Engineering section into your project's `AGENTS.md`. The `bunx github:` form is the v0.1 install path; v0.2+ will publish under an npm scope.
+
+Workspace install (default — into the current project):
+
+```bash
+bunx github:metalingusman/compound-engineering-plugin install compound-engineering --to warp
+```
+
+Global install (skills available across all projects, no `AGENTS.md` merge):
+
+```bash
+bunx github:metalingusman/compound-engineering-plugin install compound-engineering --to warp --scope global
+```
+
+After install, the Compound Engineering skills appear in Warp under `/<skill-name>` (e.g. `/ce-brainstorm`, `/ce-plan`, `/ce-work`, `/ce-code-review`, `/ce-compound`). Reviewer personas live at `.warp/skills/_ce-agents/<name>.md` and are loaded by their dispatching skills via relative paths — do not invoke them as slash commands directly.
+
+**v0.1 limitations.** Multi-persona review pipelines (`/ce-code-review`, `/ce-doc-review`, `/ce-work` quality phase) iterate reviewer personas serially in v0.1. v0.2 lowers them to Warp's `/orchestrate` primitive for true parallel execution. See [`docs/warp.md`](docs/warp.md) for the full design.
+
+**MCP servers.** Warp configures MCP servers through its in-app UI rather than via files in the repo, so the install does not write any MCP config. The postinstall hint lists the recommended servers (e.g. `agent-browser`, `XcodeBuildMCP`); register them via `/add-mcp` in Warp.
+
+To back up a previous Warp install before reinstalling, use the cleanup command:
+
+```bash
+bunx github:metalingusman/compound-engineering-plugin cleanup --target warp
+```
+
 **Pi prerequisites.** Pi does not ship a native subagent primitive, so the Pi install depends on [nicobailon/pi-subagents](https://github.com/nicobailon/pi-subagents) (required) and recommends [edlsh/pi-ask-user](https://github.com/edlsh/pi-ask-user) for richer blocking user questions:
 
 ```bash

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "compound-plugin",

--- a/docs/warp.md
+++ b/docs/warp.md
@@ -1,0 +1,239 @@
+# Warp install target
+
+This is the design and reference doc for the `--to warp` install target in
+this fork. The target is **experimental** and lives only in
+[`metalingusman/compound-engineering-plugin`](https://github.com/metalingusman/compound-engineering-plugin),
+not in the upstream `EveryInc` repository.
+
+For the user-facing install commands, see the
+[Warp section of the root README](../README.md#warp-experimental-fork-only).
+
+## Why a separate target
+
+Warp natively reads the same `SKILL.md` format Claude Code uses, so skills
+copy across with only minor text rewrites. What it does **not** have is a
+named-subagent registry: Claude's `Task(subagent_type=...)` dispatch
+primitive has no Warp counterpart. Three knock-on choices follow from that:
+
+- **Reviewer personas are written as plain markdown files** under
+  `.warp/skills/_ce-agents/<name>.md` (no `SKILL.md`, no slash command).
+  Skills reference them via relative paths and instruct the model to adopt
+  the persona for the subtask. Warp's skill discovery requires `SKILL.md`
+  in each skill directory, so plain-`.md` persona files are intentionally
+  invisible to slash-command resolution.
+- **Project context lives in `AGENTS.md`** (Warp's canonical project rules
+  file), not `CLAUDE.md`. The text rewrite pipeline rewrites `CLAUDE.md` to
+  `AGENTS.md` outside fenced code blocks. Inside fenced blocks the original
+  string is preserved because it usually appears as a literal example of
+  output the agent is asked to emit.
+- **MCP servers are not written to disk.** Warp registers MCP servers
+  through its in-app UI, not via a JSON config file in the repo. The
+  postinstall hint lists the recommended servers and points the user at
+  Warp's MCP UI; the install does not touch any MCP config.
+
+## Filesystem layout
+
+Workspace install (`--scope workspace`, the default):
+
+```
+<repo>/
+  .warp/
+    skills/
+      ce-brainstorm/SKILL.md
+      ce-plan/SKILL.md
+      ce-code-review/SKILL.md
+      ... (one directory per skill)
+      _ce-agents/
+        ce-security-sentinel.md
+        ce-architecture-strategist.md
+        ... (one file per persona)
+    compound-engineering/
+      install-manifest.json
+  AGENTS.md   (managed block fenced by markers - see below)
+```
+
+Global install (`--scope global`):
+
+```
+~/.warp/
+  skills/
+    ce-brainstorm/SKILL.md
+    ...
+    _ce-agents/
+      ...
+  compound-engineering/
+    install-manifest.json
+```
+
+The global install deliberately does **not** touch `~/AGENTS.md`. The
+AGENTS.md merge is a workspace concern; Warp does not have a global rules
+file at `~/AGENTS.md`.
+
+## AGENTS.md merge semantics
+
+The writer merges the Compound Engineering snippet into the workspace
+`AGENTS.md` using a fenced managed block:
+
+```
+<!-- compound-engineering:begin -->
+## Compound Engineering
+...managed content...
+<!-- compound-engineering:end -->
+```
+
+Three cases:
+
+1. **No `AGENTS.md` exists** -- the writer creates one containing only the
+   managed block.
+2. **`AGENTS.md` exists with no managed block** -- the writer backs up the
+   original to `AGENTS.md.bak.<timestamp>` and appends the managed block at
+   the end. User content stays untouched.
+3. **`AGENTS.md` exists with a managed block** -- the writer surgically
+   replaces the block in place, preserving everything outside the markers.
+   A backup is taken only if the new content differs from the existing
+   block.
+
+The marker strings are exported from `src/utils/warp-rewrites.ts` as
+`WARP_AGENTS_MD_BEGIN` and `WARP_AGENTS_MD_END` and are locked by tests.
+Bumping them in a patch release would orphan existing installs, so they are
+treated as a stable contract.
+
+## Skill body rewrites
+
+Every `SKILL.md` and reference `.md` file inside a skill directory is run
+through `transformContentForWarp` (`src/utils/warp-rewrites.ts`) at write
+time. The rewrite pipeline is:
+
+1. **Drop the multi-platform Interaction Method preamble** that names
+   `AskUserQuestion` (Claude), `request_user_input` (Codex), `ask_user`
+   (Gemini/Pi), etc. Replace it with a single Warp-friendly line: Warp
+   surfaces blocking prompts natively, so no tool-specific schema needs to
+   be loaded.
+2. **`CLAUDE.md` -> `AGENTS.md`** outside fenced code blocks. Inside fenced
+   blocks the original is preserved because it is usually a literal
+   example of output the agent is meant to emit.
+3. **`.claude/` -> `.warp/`** (and `~/.claude/` -> `~/.warp/`). The
+   `.claude-plugin/` manifest segment is exempt from the rewrite -- it is
+   part of the Claude plugin spec, not a user-facing path.
+4. **`Task <agent>(<args>)` dispatch lines** are collapsed to
+   `Adopt the persona in [<agent>](../_ce-agents/<agent>.md) and: <args>`.
+   The Task regex handles both bare names (`Task security-sentinel(...)`)
+   and namespaced names
+   (`Task compound-engineering:research:repo-research-analyst(...)`), and
+   runs **before** the namespaced-reference rewrite below so it doesn't
+   trip over already-rewritten links.
+5. **`compound-engineering:<category>:<agent>`** in prose, table cells, and
+   anywhere else -> a markdown link to `../_ce-agents/<agent>.md`. The
+   two-segment `compound-engineering:<skill>` form is intentionally
+   preserved -- it refers to skill namespaces (a discussion topic), not
+   agent dispatch.
+6. **Bare `@<agent-suffix>` references** (e.g. `@security-sentinel`,
+   `@performance-oracle`) -> markdown links to the persona file. The
+   suffix list mirrors the Gemini converter so we don't false-match on
+   `@username`-style mentions in prose.
+
+## Agent lowering (v0.1)
+
+Each Claude agent under `plugins/compound-engineering/agents/<category>/<name>.md`
+becomes a frontmatter-stripped markdown file at
+`<.warp/skills>/_ce-agents/<sanitized-name>.md`. The first line is a
+synthesized intro:
+
+```
+# Persona: <agent-name>
+
+<one-line description from the source frontmatter>
+
+<original persona body, transformed by transformContentForWarp>
+```
+
+The dispatching skill reads this file and instructs the model to adopt the
+persona for the duration of the subtask. v0.1 runs persona dispatches
+serially -- in skills like `/ce-code-review` and `/ce-doc-review` the
+reviewers iterate one after another rather than running in parallel.
+
+### Why the lossy parallelism is acceptable for v0.1
+
+v0.1 prioritizes shipping a working baseline. Persona fidelity is preserved
+exactly because the original prompt body is copied verbatim. Throughput is
+the only thing that suffers, and the alternative -- lowering each dispatch
+to Warp's `/orchestrate` primitive -- has design questions (does
+`/orchestrate` accept arbitrary structured subtask specs? how does the
+calling skill consume orchestrated outputs?) that warrant a deliberate
+v0.2 rather than blocking v0.1.
+
+## Reinstall and uninstall
+
+The writer keeps a manifest at
+`<warp-root>/<plugin-name>/install-manifest.json` listing the skills and
+agents written in the most recent install. On reinstall:
+
+- Skills present in the previous manifest but absent from the current
+  bundle are removed (recursive `fs.rm`).
+- Agent persona files in the same situation are removed (file `fs.rm`).
+- Skills present in both lists are overwritten in place.
+
+The manifest is namespaced under the plugin name, so a fork that installs
+multiple Compound Engineering plugins into the same Warp root keeps each
+manifest independent.
+
+To back up a previous install before reinstalling, use the cleanup command:
+
+```bash
+bunx github:metalingusman/compound-engineering-plugin cleanup --target warp
+```
+
+Cleanup reads the manifest and moves every recorded artifact into
+`<warp-root>/<plugin-name>/legacy-backup/<timestamp>/`. If no manifest
+exists the cleanup is a safe no-op -- the cleanup deliberately does **not**
+scan `.warp/skills/` for things that look CE-shaped, because that directory
+is shared with user-authored skills and a name collision is not a strong
+enough ownership signal.
+
+## Comparison with other targets
+
+The Warp target is most structurally similar to the **Gemini** target:
+both are workspace-default, both pass through skill directories with a
+content transform, both write a managed install manifest under a
+plugin-named subdirectory, and both rely on the shared `managed-artifacts`
+machinery for reinstall semantics.
+
+The differences:
+
+- **Gemini writes commands** as TOML files under `.gemini/commands/`. Warp
+  has no separate commands surface -- every skill becomes a
+  `/<skill-name>` slash command automatically.
+- **Gemini writes agents** as separate `.md` files under
+  `.gemini/agents/`. Warp has no native agent-as-resource concept, so
+  agent personas live inside the skills tree as inert reference files.
+- **Gemini writes MCP server config** to `settings.json`. Warp configures
+  MCP through its in-app UI; the install only surfaces a postinstall hint.
+- **Gemini's AGENTS.md story** is whatever the user already maintains.
+  Warp's writer actively merges a Compound Engineering snippet into the
+  workspace's `AGENTS.md`, fenced with stable markers so reinstalls are
+  idempotent.
+
+## Roadmap
+
+- **v0.2:** Lower persona dispatches to Warp's `/orchestrate` primitive
+  so multi-reviewer pipelines run in parallel. Switch the package to npm
+  (`@metalingusman/compound-plugin`) and drop the `bunx github:` install
+  path from documentation.
+- **v0.3:** Warp-native polish -- Tab Configs for `/ce-worktree`, Warp
+  Drive Prompt seeding, Oz scheduled-agent recipes for
+  `/ce-compound-refresh` and `/ce-clean-gone-branches`, code-review pane
+  integration so `/ce-code-review` findings land as inline review comments.
+- **v0.4 (optional):** MCP-backed agent dispatch server for users who want
+  true persona parallelism without `/orchestrate`. This is gated on usage
+  data showing v0.2's `/orchestrate` lowering is insufficient.
+
+## Filing issues
+
+Warp-specific bugs and feature requests go in this fork's tracker rather
+than upstream. Tag issues with `target:warp` so they're easy to filter.
+
+If a bug reproduces on multiple targets (e.g. a skill body issue that
+affects Warp, Gemini, and OpenCode equally), file it upstream against
+[`EveryInc/compound-engineering-plugin`](https://github.com/EveryInc/compound-engineering-plugin)
+-- those skills are owned by the upstream maintainers, and Warp picks them
+up via rebases.

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -11,6 +11,7 @@ import { convertClaudeToGemini } from "../converters/claude-to-gemini"
 import { convertClaudeToKiro } from "../converters/claude-to-kiro"
 import { convertClaudeToOpenCode } from "../converters/claude-to-opencode"
 import { convertClaudeToPi } from "../converters/claude-to-pi"
+import { convertClaudeToWarp } from "../converters/claude-to-warp"
 import {
   getLegacyCodexArtifacts,
   getLegacyCopilotArtifacts,
@@ -22,14 +23,18 @@ import {
   getLegacyPluginArtifacts,
   getLegacyWindsurfArtifacts,
 } from "../data/plugin-legacy-artifacts"
-import { moveLegacyArtifactToBackup } from "../targets/managed-artifacts"
+import {
+  moveLegacyArtifactToBackup,
+  readManagedInstallManifestWithLegacyFallback,
+  sanitizeManagedPluginName,
+} from "../targets/managed-artifacts"
 import { isManagedCodexAgentsSymlink, readCodexInstallManifest, resolveCodexManagedRoots } from "../targets/codex"
 import { classifyCodexLegacyPromptOwnership } from "../utils/legacy-cleanup"
 import { isSafeManagedPath, pathExists, readJson, sanitizePathName } from "../utils/files"
 import { resolveOpenCodeGlobalRoot } from "../utils/opencode-config"
 import { expandHome, resolveTargetHome } from "../utils/resolve-home"
 
-const cleanupTargets = ["codex", "opencode", "pi", "gemini", "kiro", "copilot", "droid", "qwen", "windsurf"] as const
+const cleanupTargets = ["codex", "opencode", "pi", "gemini", "kiro", "copilot", "droid", "qwen", "windsurf", "warp"] as const
 type CleanupTarget = typeof cleanupTargets[number]
 
 type CleanupResult = {
@@ -52,7 +57,7 @@ export default defineCommand({
     target: {
       type: "string",
       default: "all",
-      description: "Target to clean: codex | opencode | pi | gemini | kiro | copilot | droid | qwen | windsurf | all",
+      description: "Target to clean: codex | opencode | pi | gemini | kiro | copilot | droid | qwen | windsurf | warp | all",
     },
     output: {
       type: "string",
@@ -104,6 +109,11 @@ export default defineCommand({
       alias: "windsurf-home",
       description: "Deprecated Windsurf root to clean (default: ~/.codeium/windsurf)",
     },
+    warpHome: {
+      type: "string",
+      alias: "warp-home",
+      description: "Warp root to clean for global installs (default: ~/.warp). Workspace installs are detected via --output.",
+    },
     agentsHome: {
       type: "string",
       alias: "agents-home",
@@ -132,11 +142,13 @@ export default defineCommand({
       droidHome: resolveTargetHome(args.droidHome, path.join(os.homedir(), ".factory")),
       qwenHome: resolveTargetHome(args.qwenHome, path.join(os.homedir(), ".qwen")),
       windsurfHome: resolveTargetHome(args.windsurfHome, path.join(os.homedir(), ".codeium", "windsurf")),
+      warpHome: resolveTargetHome(args.warpHome, path.join(os.homedir(), ".warp")),
       agentsHome: resolveTargetHome(args.agentsHome, path.join(os.homedir(), ".agents")),
       workspaceRoot: outputRoot,
       hasExplicitOutput: hasExplicitValue(args.output),
       hasExplicitGeminiHome,
       hasExplicitOpenCodeHome,
+      hasExplicitWarpHome: hasExplicitValue(args.warpHome),
     }
 
     const results: CleanupResult[] = []
@@ -165,11 +177,13 @@ async function cleanupTarget(
     droidHome: string
     qwenHome: string
     windsurfHome: string
+    warpHome: string
     agentsHome: string
     workspaceRoot: string
     hasExplicitOutput: boolean
     hasExplicitGeminiHome: boolean
     hasExplicitOpenCodeHome: boolean
+    hasExplicitWarpHome: boolean
   },
 ): Promise<CleanupResult[]> {
   switch (target) {
@@ -244,6 +258,21 @@ async function cleanupTarget(
         ? [resolveWindsurfWorkspaceRoot(roots.workspaceRoot)]
         : await dedupeRoots([roots.windsurfHome, resolveWindsurfWorkspaceRoot(roots.workspaceRoot)])
       return await Promise.all(rootsToClean.map((root) => cleanupWindsurf(plugin, root)))
+    }
+    case "warp": {
+      // Warp cleanup uses the install manifest only — there is no historical
+      // legacy allow-list because v0.1 is the first release for this target.
+      // Mirror the Gemini/Copilot dedup pattern so concurrent renames cannot
+      // race on the same directory if --warp-home and --output collide.
+      if (roots.hasExplicitWarpHome) {
+        return [await cleanupWarp(plugin, roots.warpHome)]
+      }
+      const workspaceWarp = resolveWarpWorkspaceRoot(roots.workspaceRoot)
+      if (roots.hasExplicitOutput) {
+        return [await cleanupWarp(plugin, workspaceWarp)]
+      }
+      const rootsToClean = await dedupeRoots([workspaceWarp, roots.warpHome])
+      return await Promise.all(rootsToClean.map((root) => cleanupWarp(plugin, root)))
     }
   }
 }
@@ -727,4 +756,49 @@ function resolveDroidWorkspaceRoot(outputRoot: string): string {
 
 function resolveWindsurfWorkspaceRoot(outputRoot: string): string {
   return path.basename(outputRoot) === ".windsurf" ? outputRoot : path.join(outputRoot, ".windsurf")
+}
+
+function resolveWarpWorkspaceRoot(outputRoot: string): string {
+  return path.basename(outputRoot) === ".warp" ? outputRoot : path.join(outputRoot, ".warp")
+}
+
+/**
+ * Manifest-driven cleanup for the Warp target.
+ *
+ * v0.1 is the first release of this target, so there is no historical
+ * legacy allow-list to consult. Cleanup reads the install manifest written
+ * by `writeWarpBundle`, moves every recorded artifact into the
+ * `<warp>/<plugin>/legacy-backup/<timestamp>/` tree, and exits. If no
+ * manifest exists, the cleanup is a safe no-op — we deliberately do NOT
+ * scan `.warp/skills/` for things that look CE-shaped because that
+ * directory is shared with user-authored skills.
+ */
+async function cleanupWarp(
+  plugin: Awaited<ReturnType<typeof loadClaudePlugin>>,
+  warpRoot: string,
+): Promise<CleanupResult> {
+  // Convert solely to confirm the bundle is parseable; we only consult the
+  // manifest below for the artifact list. The conversion is cheap and keeps
+  // the cleanup-target signature consistent with other targets.
+  convertClaudeToWarp(plugin, {
+    agentMode: "subagent",
+    inferTemperature: true,
+    permissions: "none",
+    codexIncludeSkills: false,
+  })
+  const pluginName = sanitizeManagedPluginName(plugin.manifest.name)
+  const managedDir = path.join(warpRoot, pluginName)
+  const manifest = await readManagedInstallManifestWithLegacyFallback(managedDir, pluginName)
+  if (!manifest) return { target: "warp", root: warpRoot, moved: 0 }
+
+  const skillsDir = path.join(warpRoot, "skills")
+  const agentsDir = path.join(skillsDir, "_ce-agents")
+  let moved = 0
+  for (const skillName of manifest.groups.skills ?? []) {
+    moved += await moveIfExists(managedDir, "skills", skillsDir, skillName, "Warp")
+  }
+  for (const agentFile of manifest.groups.agents ?? []) {
+    moved += await moveIfExists(managedDir, "agents", agentsDir, agentFile, "Warp")
+  }
+  return { target: "warp", root: warpRoot, moved }
 }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -25,7 +25,7 @@ export default defineCommand({
     to: {
       type: "string",
       default: "opencode",
-      description: "Target format (opencode | codex | pi | gemini | kiro | all)",
+      description: "Target format (opencode | codex | pi | gemini | kiro | warp | all)",
     },
     output: {
       type: "string",

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -28,7 +28,7 @@ export default defineCommand({
     to: {
       type: "string",
       default: "opencode",
-      description: "Target format (opencode | codex | pi | gemini | kiro | all)",
+      description: "Target format (opencode | codex | pi | gemini | kiro | warp | all)",
     },
     output: {
       type: "string",

--- a/src/converters/claude-to-warp.ts
+++ b/src/converters/claude-to-warp.ts
@@ -1,0 +1,161 @@
+/**
+ * Convert a parsed Claude plugin into a Warp install bundle.
+ *
+ * The Warp converter is intentionally light. Most of the work is in the
+ * writer (`src/targets/warp.ts`), which copies skill directories
+ * verbatim and applies the shared `transformContentForWarp` rewrites at
+ * write time. The converter's job is to:
+ *
+ *   - Filter skills by `ce_platforms` so authors can opt skills out of Warp
+ *     (mirrors the Gemini target).
+ *   - Lower each Claude agent into a frontmatter-stripped persona markdown
+ *     file under `_ce-agents/<name>.md`. Frontmatter (model, tools,
+ *     description) is replaced with a one-line intro because Warp does not
+ *     have a named-subagent registry — these files are read by the
+ *     dispatching skill at runtime, not loaded by Warp itself.
+ *   - Stage a static `AGENTS.md` snippet describing where compound-
+ *     engineering artifacts land (docs/brainstorms, docs/plans,
+ *     docs/solutions, todos/). The writer merges this into the workspace
+ *     AGENTS.md inside fenced markers so reinstalls are idempotent and
+ *     human-reversible.
+ *   - Surface the names of recommended MCP servers so the writer can print
+ *     a postinstall hint pointing the user at Warp's MCP UI.
+ */
+
+import { type ClaudeAgent, type ClaudePlugin, filterSkillsByPlatform } from "../types/claude"
+import { sanitizePathName } from "../utils/files"
+import { transformContentForWarp } from "../utils/warp-rewrites"
+import type { ClaudeToOpenCodeOptions } from "./claude-to-opencode"
+import type { WarpAgentFile, WarpBundle } from "../types/warp"
+
+export type ClaudeToWarpOptions = ClaudeToOpenCodeOptions
+
+const WARP_PLATFORM_KEY = "warp"
+
+/**
+ * Static AGENTS.md snippet appended to the workspace AGENTS.md by the
+ * writer. Keep this a stable string so the begin/end markers around it can
+ * be used to surgically replace the section on reinstall. It deliberately
+ * does not duplicate the upstream `plugins/compound-engineering/CLAUDE.md`
+ * — that file is part of the bundled plugin, not a Warp-specific
+ * convention surface.
+ */
+const WARP_AGENTS_SNIPPET = `## Compound Engineering
+
+This project uses the [compound-engineering](https://github.com/EveryInc/compound-engineering-plugin) plugin via the Warp target.
+
+The core loop:
+
+- \`/ce-brainstorm\` — Interactive Q&A to define what to build.
+- \`/ce-plan\` — Turn brainstorms or rough ideas into structured plans.
+- \`/ce-work\` — Execute plans with worktrees and task tracking.
+- \`/ce-code-review\` — Multi-persona review before merging (v0.1: serial; v0.2: parallel via \`/orchestrate\`).
+- \`/ce-compound\` — Codify learnings so the next cycle starts smarter.
+
+Generated artifacts live under:
+
+- \`docs/brainstorms/\` — requirements documents from \`/ce-brainstorm\`.
+- \`docs/plans/\` — implementation plans from \`/ce-plan\`.
+- \`docs/solutions/\` — institutional learnings from \`/ce-compound\`, organized by category with YAML frontmatter.
+- \`todos/\` — review findings and prioritized work items.
+
+Personas dispatched by review/work skills live at \`.warp/skills/_ce-agents/<name>.md\` and are referenced by the dispatching skill via relative paths. Do not invoke them as slash commands directly.
+`
+
+/**
+ * Recommended MCP servers the upstream plugin uses. Surfaced as a
+ * postinstall hint rather than written to disk because Warp configures MCP
+ * in the in-app UI rather than via files in the repo.
+ */
+const RECOMMENDED_MCP_SERVERS = [
+  "agent-browser",
+  "XcodeBuildMCP",
+]
+
+export function convertClaudeToWarp(
+  plugin: ClaudePlugin,
+  _options: ClaudeToWarpOptions,
+): WarpBundle {
+  // Authors can opt skills out of Warp by setting ce_platforms in
+  // frontmatter. Skills without that key are available everywhere.
+  const platformSkills = filterSkillsByPlatform(plugin.skills, WARP_PLATFORM_KEY)
+
+  const skillDirs = platformSkills.map((skill) => ({
+    name: skill.name,
+    sourceDir: skill.sourceDir,
+  }))
+
+  const agents = lowerAgents(plugin.agents)
+
+  if (plugin.hooks && Object.keys(plugin.hooks.hooks).length > 0) {
+    console.warn(
+      "Warning: Warp does not have a hooks primitive. Hook definitions were skipped during conversion.",
+    )
+  }
+
+  return {
+    pluginName: plugin.manifest.name,
+    skillDirs,
+    agents,
+    project: {
+      agentsMd: WARP_AGENTS_SNIPPET,
+    },
+    recommendedMcpServers: pickRecommendedMcpServers(plugin),
+  }
+}
+
+/**
+ * Convert a Claude agent definition (frontmatter + persona body) into a
+ * frontmatter-free persona markdown file. The first non-empty line of the
+ * body is preceded by a synthesized intro that names the persona and
+ * (when available) summarizes its description, so the dispatching skill's
+ * agent has enough context after reading the file.
+ */
+function lowerAgents(agents: ClaudeAgent[]): WarpAgentFile[] {
+  const seen = new Set<string>()
+  const lowered: WarpAgentFile[] = []
+  for (const agent of agents) {
+    const safeName = sanitizePathName(agent.name)
+    if (seen.has(safeName)) {
+      console.warn(
+        `Skipping agent "${agent.name}": sanitized name "${safeName}" collides with another agent.`,
+      )
+      continue
+    }
+    seen.add(safeName)
+    const intro = renderAgentIntro(agent)
+    const body = transformContentForWarp(agent.body.trim())
+    const content = body.length > 0 ? `${intro}\n\n${body}\n` : `${intro}\n`
+    lowered.push({ name: safeName, content })
+  }
+  return lowered
+}
+
+function renderAgentIntro(agent: ClaudeAgent): string {
+  const description = agent.description?.trim()
+  const heading = `# Persona: ${agent.name}`
+  if (!description) return heading
+  return `${heading}\n\n${description}`
+}
+
+/**
+ * Cross-reference the plugin's declared MCP servers against our recommended
+ * list so we only nag the user about ones the plugin actually requests.
+ * Falls back to the static recommended list if the plugin manifest does not
+ * declare any MCP servers (older bundled plugins, custom forks).
+ */
+function pickRecommendedMcpServers(plugin: ClaudePlugin): string[] {
+  const declared = Object.keys(plugin.mcpServers ?? {})
+  if (declared.length === 0) return RECOMMENDED_MCP_SERVERS.slice()
+  const recommendedSet = new Set(RECOMMENDED_MCP_SERVERS)
+  const ordered: string[] = []
+  for (const name of declared) {
+    if (recommendedSet.has(name)) ordered.push(name)
+  }
+  // Always include declared servers, even ones we haven't curated, so users
+  // see the full picture. De-dupe while preserving insertion order.
+  for (const name of declared) {
+    if (!ordered.includes(name)) ordered.push(name)
+  }
+  return ordered
+}

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -4,11 +4,13 @@ import { convertClaudeToCodex } from "../converters/claude-to-codex"
 import { convertClaudeToPi } from "../converters/claude-to-pi"
 import { convertClaudeToGemini } from "../converters/claude-to-gemini"
 import { convertClaudeToKiro } from "../converters/claude-to-kiro"
+import { convertClaudeToWarp } from "../converters/claude-to-warp"
 import { writeOpenCodeBundle } from "./opencode"
 import { writeCodexBundle } from "./codex"
 import { writePiBundle } from "./pi"
 import { writeGeminiBundle } from "./gemini"
 import { writeKiroBundle } from "./kiro"
+import { writeWarpBundle } from "./warp"
 
 export type TargetScope = "global" | "workspace"
 
@@ -77,5 +79,16 @@ export const targets: Record<string, TargetHandler> = {
     implemented: true,
     convert: convertClaudeToKiro as TargetHandler["convert"],
     write: writeKiroBundle as TargetHandler["write"],
+  },
+  warp: {
+    name: "warp",
+    implemented: true,
+    // Workspace install is the canonical Warp surface (skills land under
+    // <repo>/.warp/skills and AGENTS.md is merged at the repo root). Global
+    // installs go to ~/.warp/skills and skip the AGENTS.md merge.
+    defaultScope: "workspace",
+    supportedScopes: ["workspace", "global"],
+    convert: convertClaudeToWarp as TargetHandler["convert"],
+    write: writeWarpBundle as TargetHandler["write"],
   },
 }

--- a/src/targets/warp.ts
+++ b/src/targets/warp.ts
@@ -1,0 +1,240 @@
+/**
+ * Filesystem writer for the Warp install target.
+ *
+ * Layout (workspace install):
+ *   <root>/.warp/skills/<skill-name>/SKILL.md
+ *   <root>/.warp/skills/<skill-name>/<reference files...>
+ *   <root>/.warp/skills/_ce-agents/<agent-name>.md
+ *   <root>/.warp/<plugin-name>/install-manifest.json
+ *   <root>/AGENTS.md   (merged in-place with begin/end markers)
+ *
+ * Layout (global install):
+ *   ~/.warp/skills/<skill-name>/SKILL.md
+ *   ~/.warp/skills/_ce-agents/<agent-name>.md
+ *   ~/.warp/<plugin-name>/install-manifest.json
+ *
+ * The write path mirrors the Gemini/Kiro targets:
+ *   1. Resolve the .warp directory from `outputRoot` (basename detection
+ *      matches `path/to/.warp` or appends `.warp` to a workspace root).
+ *   2. Read the previous install manifest under `<root>/<plugin>/`. Use it
+ *      to drop skill/agent directories that are no longer in the current
+ *      bundle so removed components don't linger after upgrade.
+ *   3. Copy each skill directory through `copySkillDir` with the Warp
+ *      content transform applied to all markdown so reference files (not
+ *      just SKILL.md) get the same `.claude/` -> `.warp/` and agent-link
+ *      rewrites.
+ *   4. Write each lowered agent persona under `_ce-agents/`.
+ *   5. Merge the AGENTS.md snippet at the workspace root, fenced with the
+ *      `compound-engineering:begin/end` markers so reinstalls update only
+ *      the managed block.
+ *   6. Print a postinstall hint with MCP-server registration guidance and
+ *      the v0.1 limitations note.
+ */
+
+import path from "path"
+import { backupFile, copySkillDir, ensureDir, pathExists, readText, sanitizePathName, writeText } from "../utils/files"
+import {
+  archiveLegacyInstallManifestIfOwned,
+  cleanupCurrentManagedDirectory,
+  cleanupRemovedManagedDirectories,
+  cleanupRemovedManagedFiles,
+  readManagedInstallManifestWithLegacyFallback,
+  resolveManagedSegment,
+  sanitizeManagedPluginName,
+  writeManagedInstallManifest,
+} from "./managed-artifacts"
+import type { TargetScope } from "./index"
+import type { WarpBundle } from "../types/warp"
+import { transformContentForWarp, WARP_AGENTS_MD_BEGIN, WARP_AGENTS_MD_END } from "../utils/warp-rewrites"
+
+/** Directory name used for the shared persona files referenced by skills. */
+const AGENTS_DIR_NAME = "_ce-agents"
+
+export async function writeWarpBundle(
+  outputRoot: string,
+  bundle: WarpBundle,
+  _scope?: TargetScope,
+): Promise<void> {
+  const pluginName = bundle.pluginName ? sanitizeManagedPluginName(bundle.pluginName) : undefined
+  const paths = resolveWarpPaths(outputRoot, pluginName)
+  const manifest = pluginName
+    ? await readManagedInstallManifestWithLegacyFallback(paths.managedDir, pluginName)
+    : null
+
+  const currentSkills = bundle.skillDirs.map((skill) => sanitizePathName(skill.name))
+  const currentAgents = bundle.agents.map((agent) => `${sanitizePathName(agent.name)}.md`)
+
+  await ensureDir(paths.warpDir)
+  await ensureDir(paths.skillsDir)
+
+  // Drop skills/agents recorded in the previous manifest that are no
+  // longer in the current bundle. This is what makes upgrades safe: a
+  // skill removed in plugin v3 won't linger from the install of plugin v2.
+  await cleanupRemovedManagedDirectories(paths.skillsDir, manifest, "skills", currentSkills)
+  await cleanupRemovedManagedFiles(paths.agentsDir, manifest, "agents", currentAgents)
+
+  for (const skill of bundle.skillDirs) {
+    const skillName = sanitizePathName(skill.name)
+    const targetDir = path.join(paths.skillsDir, skillName)
+    await cleanupCurrentManagedDirectory(targetDir, manifest, "skills", skillName)
+    // Apply the Warp transform to every .md (not just SKILL.md) so
+    // reference files inside a skill directory pick up agent-link and
+    // path rewrites the same way the entry SKILL.md does.
+    await copySkillDir(skill.sourceDir, targetDir, transformContentForWarp, true)
+  }
+
+  if (bundle.agents.length > 0) {
+    await ensureDir(paths.agentsDir)
+    for (const agent of bundle.agents) {
+      const filename = `${sanitizePathName(agent.name)}.md`
+      await writeText(path.join(paths.agentsDir, filename), agent.content)
+    }
+  }
+
+  if (paths.workspaceRoot && bundle.project.agentsMd) {
+    await mergeAgentsMd(paths.workspaceRoot, bundle.project.agentsMd)
+  }
+
+  if (pluginName) {
+    await writeManagedInstallManifest(paths.managedDir, {
+      version: 1,
+      pluginName,
+      groups: {
+        skills: currentSkills,
+        agents: currentAgents,
+      },
+    })
+    await archiveLegacyInstallManifestIfOwned(paths.managedDir, pluginName)
+  }
+
+  printPostinstallHint(bundle, paths)
+}
+
+type WarpPaths = {
+  /** The .warp/ directory itself. */
+  warpDir: string
+  /** Directory where managed install metadata lives. */
+  managedDir: string
+  /** .warp/skills directory. */
+  skillsDir: string
+  /** .warp/skills/_ce-agents directory. */
+  agentsDir: string
+  /**
+   * Workspace root for AGENTS.md merge, or undefined when this is a global
+   * install (~/.warp) — in that case the AGENTS.md snippet is skipped.
+   */
+  workspaceRoot: string | undefined
+}
+
+function resolveWarpPaths(outputRoot: string, pluginName?: string): WarpPaths {
+  const managedSegment = resolveManagedSegment(pluginName)
+  const base = path.basename(outputRoot)
+  // When the caller already passed a path ending in `.warp`, treat it as the
+  // .warp dir directly (matches the Gemini target's basename heuristic).
+  if (base === ".warp") {
+    return {
+      warpDir: outputRoot,
+      managedDir: path.join(outputRoot, managedSegment),
+      skillsDir: path.join(outputRoot, "skills"),
+      agentsDir: path.join(outputRoot, "skills", AGENTS_DIR_NAME),
+      // Walk up one level to find the workspace root candidate. For global
+      // installs (~/.warp) we don't want to touch ~/AGENTS.md, so the caller
+      // signals that case via TargetScope below — but at this layer we
+      // simply check whether the parent looks like the user's home dir and
+      // skip the merge if so. The test for that is in mergeAgentsMd's caller.
+      workspaceRoot: deriveWorkspaceRootFromWarpDir(outputRoot),
+    }
+  }
+  // Otherwise treat `outputRoot` as a workspace root and nest under .warp/.
+  const warpDir = path.join(outputRoot, ".warp")
+  return {
+    warpDir,
+    managedDir: path.join(warpDir, managedSegment),
+    skillsDir: path.join(warpDir, "skills"),
+    agentsDir: path.join(warpDir, "skills", AGENTS_DIR_NAME),
+    workspaceRoot: outputRoot,
+  }
+}
+
+/**
+ * For an outputRoot that ends in `.warp`, infer whether the parent directory
+ * is a workspace (project) root or a home directory. Global installs target
+ * `~/.warp`, in which case we do not write AGENTS.md (~/AGENTS.md is a
+ * user-level file we would not want to clobber). Workspace installs target
+ * `<repo>/.warp`, in which case the parent is the workspace root.
+ */
+function deriveWorkspaceRootFromWarpDir(warpDir: string): string | undefined {
+  const parent = path.dirname(warpDir)
+  // `os.homedir()` would be canonical, but we avoid importing `os` here so
+  // the comparison stays based on the resolved warpDir we were given. The
+  // caller — typically `resolveTargetOutputRoot` — passes either a resolved
+  // workspace root or the user's home; if the parent of warpDir matches the
+  // user's home as recorded in HOME, we treat that as a global install.
+  const home = process.env.HOME ?? process.env.USERPROFILE
+  if (home && path.resolve(parent) === path.resolve(home)) {
+    return undefined
+  }
+  return parent
+}
+
+/**
+ * Idempotently merge `snippet` into `<workspaceRoot>/AGENTS.md`.
+ *
+ * - If AGENTS.md does not exist, write it with the begin/end markers around
+ *   the snippet.
+ * - If AGENTS.md exists and already contains a managed block, replace the
+ *   block in place (preserving everything outside the markers).
+ * - If AGENTS.md exists but does not contain a managed block, append the
+ *   block to the end of the file. Back the original up before any edit.
+ */
+async function mergeAgentsMd(workspaceRoot: string, snippet: string): Promise<void> {
+  const target = path.join(workspaceRoot, "AGENTS.md")
+  const block = `${WARP_AGENTS_MD_BEGIN}\n${snippet.trim()}\n${WARP_AGENTS_MD_END}\n`
+
+  if (!(await pathExists(target))) {
+    await writeText(target, block)
+    return
+  }
+
+  const existing = await readText(target)
+  const beginIdx = existing.indexOf(WARP_AGENTS_MD_BEGIN)
+  const endIdx = existing.indexOf(WARP_AGENTS_MD_END)
+
+  // If both markers are present and well-ordered, surgically replace the
+  // managed block in place. Otherwise back up and append.
+  if (beginIdx !== -1 && endIdx !== -1 && endIdx > beginIdx) {
+    const before = existing.slice(0, beginIdx)
+    // Skip past the closing marker line so the replacement keeps the file's
+    // newline cadence intact.
+    const afterStart = endIdx + WARP_AGENTS_MD_END.length
+    const after = existing.slice(afterStart).replace(/^\n/, "")
+    const updated = `${before}${block}${after}`
+    if (updated === existing) return
+    await backupFile(target)
+    await writeText(target, updated)
+    return
+  }
+
+  await backupFile(target)
+  // Ensure exactly one blank line between the user's content and the
+  // appended managed block, regardless of how the existing file ends.
+  const trimmed = existing.replace(/\s+$/, "")
+  const updated = `${trimmed}\n\n${block}`
+  await writeText(target, updated)
+}
+
+function printPostinstallHint(bundle: WarpBundle, paths: WarpPaths): void {
+  console.log(`Installed ${bundle.skillDirs.length} skill(s) and ${bundle.agents.length} persona(s) to ${paths.skillsDir}`)
+  if (paths.workspaceRoot) {
+    console.log(`Updated AGENTS.md at ${path.join(paths.workspaceRoot, "AGENTS.md")} (managed block fenced by compound-engineering markers).`)
+  }
+  console.log(`Slash commands are available in Warp via /<skill-name> (e.g. /ce-brainstorm, /ce-plan, /ce-compound).`)
+  if (bundle.recommendedMcpServers.length > 0) {
+    console.log(
+      `Recommended MCP servers (configure via Warp's MCP UI): ${bundle.recommendedMcpServers.join(", ")}.`,
+    )
+  }
+  console.log(
+    "v0.1 note: review pipelines (/ce-code-review, /ce-doc-review) run reviewer personas serially. v0.2 will lower them to /orchestrate for parallel execution.",
+  )
+}

--- a/src/types/warp.ts
+++ b/src/types/warp.ts
@@ -1,0 +1,50 @@
+/**
+ * Type definitions for the Warp install target.
+ *
+ * Warp natively reads the Claude Code SKILL.md format (YAML frontmatter +
+ * markdown body) under `.warp/skills/<name>/SKILL.md`. It does not expose a
+ * named-subagent registry, so Claude agents are lowered to plain markdown
+ * persona files under a shared `_ce-agents/` sibling directory; dispatching
+ * skills reference them via relative paths. AGENTS.md is the canonical
+ * project-context file in Warp (CLAUDE.md is rewritten on copy).
+ *
+ * MCP / hook configuration is intentionally absent from this bundle: Warp
+ * users register MCP servers through the in-app UI rather than via files
+ * checked into the repo, and Warp does not have a hooks primitive.
+ */
+
+export type WarpSkillDir = {
+  name: string
+  sourceDir: string
+}
+
+export type WarpAgentFile = {
+  /** Sanitized agent name, used as the .md filename under `_ce-agents/`. */
+  name: string
+  /** Full markdown body (no frontmatter) to be written verbatim. */
+  content: string
+}
+
+export type WarpProjectFiles = {
+  /**
+   * Optional AGENTS.md body to merge into the workspace root. When the user
+   * already has an AGENTS.md, the writer appends a fenced section under a
+   * known header so the merge is idempotent and human-reversible.
+   */
+  agentsMd?: string
+}
+
+export type WarpBundle = {
+  pluginName?: string
+  /** Pass-through skill directories. The writer copies each one and applies content rewrites to SKILL.md and reference .md files. */
+  skillDirs: WarpSkillDir[]
+  /** Lowered agent personas, written under `<root>/.warp/skills/_ce-agents/<name>.md`. */
+  agents: WarpAgentFile[]
+  /** Project-level files (AGENTS.md, etc.). */
+  project: WarpProjectFiles
+  /**
+   * Names of MCP servers the plugin recommends. Surfaced as a postinstall
+   * hint pointing the user at Warp's MCP UI; not written to disk.
+   */
+  recommendedMcpServers: string[]
+}

--- a/src/utils/detect-tools.ts
+++ b/src/utils/detect-tools.ts
@@ -73,6 +73,15 @@ const detectableTools: DetectableTool[] = [
       path.join(cwd, ".qwen"),
     ],
   },
+  {
+    name: "warp",
+    detectPaths: (home, cwd) => [
+      // Workspace .warp/ is the canonical install surface; ~/.warp also
+      // counts because the global install lands there.
+      path.join(cwd, ".warp"),
+      path.join(home, ".warp"),
+    ],
+  },
 ]
 
 export async function detectInstalledTools(

--- a/src/utils/resolve-output.ts
+++ b/src/utils/resolve-output.ts
@@ -22,6 +22,16 @@ export function resolveTargetOutputRoot(options: {
     const base = hasExplicitOutput ? outputRoot : process.cwd()
     return path.join(base, ".kiro")
   }
+  if (targetName === "warp") {
+    // Workspace install (default) writes to <cwd>/.warp; --scope global
+    // writes to ~/.warp and skips the AGENTS.md merge. An explicit --output
+    // overrides the workspace branch.
+    if (options.scope === "global") {
+      return path.join(process.env.HOME ?? process.env.USERPROFILE ?? process.cwd(), ".warp")
+    }
+    const base = hasExplicitOutput ? outputRoot : process.cwd()
+    return path.join(base, ".warp")
+  }
   if (targetName === "opencode") {
     // Without an explicit --output, default to the OpenCode global-config root
     // (OPENCODE_CONFIG_DIR or ~/.config/opencode). With an explicit --output,

--- a/src/utils/warp-rewrites.ts
+++ b/src/utils/warp-rewrites.ts
@@ -1,0 +1,190 @@
+/**
+ * Data-driven text rewrites applied to Claude plugin content (skills, agents,
+ * commands, project conventions) when targeting Warp.
+ *
+ * The Warp target is implemented as an additive converter — the upstream
+ * SKILL.md format is already compatible, so we only need to translate
+ * platform-specific divergences:
+ *
+ *   1. Project context file: `CLAUDE.md` → `AGENTS.md`. Warp reads project
+ *      rules from AGENTS.md (or WARP.md for legacy projects).
+ *   2. Per-platform config dirs: `.claude/` → `.warp/`, `~/.claude/` →
+ *      `~/.warp/`. Mirrors the rewrite the OpenCode/Gemini converters do.
+ *   3. The multi-platform Interaction Method preamble that names
+ *      `AskUserQuestion` (Claude), `request_user_input` (Codex), `ask_user`
+ *      (Gemini/Pi), etc. is collapsed to a single Warp-friendly line: Warp's
+ *      agent surfaces blocking prompts natively without a tool name.
+ *   4. Agent dispatch references — both fully-qualified
+ *      (`compound-engineering:review:security-sentinel`) and bare
+ *      (`Task security-sentinel(...)`, `@security-sentinel`) — are rewritten
+ *      to instruct the model to read a co-located persona file under
+ *      `_ce-agents/` and adopt the persona for the subtask. v0.2 will replace
+ *      these with `/orchestrate` calls; v0.1 runs the personas serially.
+ *
+ * Rewrites are intentionally pure functions over strings so they can be unit
+ * tested without filesystem state. The same module runs at write time over
+ * each copied SKILL.md and at convert time over agent/project bodies.
+ */
+
+/**
+ * Sentinel relative path used by skill bodies to reference a persona file.
+ * Skills live at `<root>/.warp/skills/<skill-name>/SKILL.md`; agents live at
+ * `<root>/.warp/skills/_ce-agents/<agent-name>.md`. Hence `../_ce-agents/`.
+ */
+export const WARP_AGENTS_RELATIVE_DIR = "../_ce-agents"
+
+/**
+ * Markers used to fence the compound-engineering section inside an existing
+ * AGENTS.md so reinstalls update only the managed block.
+ */
+export const WARP_AGENTS_MD_BEGIN = "<!-- compound-engineering:begin -->"
+export const WARP_AGENTS_MD_END = "<!-- compound-engineering:end -->"
+
+/**
+ * Best-effort regex matching the multi-platform Interaction Method block
+ * that appears verbatim in many compound-engineering skill bodies. We do not
+ * try to parse it; we just recognize the opening sentence and replace
+ * everything up to and including the trailing "Never silently skip the
+ * question." line that closes the block in the upstream content.
+ */
+const INTERACTION_METHOD_BLOCK = /^## Interaction Method\n[\s\S]*?Never silently skip the question\.[^\n]*\n?/m
+
+const INTERACTION_METHOD_REPLACEMENT = `## Interaction Method
+
+When asking the user a question, ask one focused question at a time and prefer single-select choices when natural options exist. Wait for the user's reply before proceeding. Warp surfaces blocking prompts natively, so no tool-specific schema needs to be loaded.
+`
+
+/**
+ * Rewrite Claude-Code-flavored content into Warp-flavored content.
+ *
+ * Order matters: we rewrite the namespaced agent references before the bare
+ * `@agent-suffix` form so we don't double-transform `@security-sentinel`
+ * after it's already been linked.
+ */
+export function transformContentForWarp(input: string): string {
+  let out = input
+
+  // 1. Drop the multi-platform Interaction Method preamble.
+  out = out.replace(INTERACTION_METHOD_BLOCK, INTERACTION_METHOD_REPLACEMENT)
+
+  // 2. Project-context file: CLAUDE.md -> AGENTS.md.
+  //
+  //    We rewrite outside fenced code blocks only. Inside code blocks the
+  //    original CLAUDE.md filename may be the literal subject of an example
+  //    (e.g. "create CLAUDE.md with..."). The block-level walk below reuses
+  //    a simple state machine because the regex flavor we have here doesn't
+  //    support look-around across multi-line code fences.
+  out = rewriteOutsideFencedBlocks(out, (chunk) =>
+    chunk.replace(/\bCLAUDE\.md\b/g, "AGENTS.md"),
+  )
+
+  // 3. Per-platform config dirs.
+  //
+  //    We deliberately do NOT rewrite the literal `.claude-plugin/` segment,
+  //    which names the plugin manifest directory and is part of the Claude
+  //    Code plugin spec rather than a user-facing path.
+  out = out
+    .replace(/~\/\.claude\//g, "~/.warp/")
+    .replace(/(?<!\.claude-plugin)\.claude\/(?!plugin)/g, ".warp/")
+
+  // 4. Bare `Task <agent>(<args>)` dispatch lines (the Claude Code Task
+  //    tool's invocation grammar), used in skills like ce-review and
+  //    ce-doc-review. We collapse them to a directive that tells the Warp
+  //    agent to read the persona file and adopt it. This MUST run before the
+  //    namespaced-reference rewrite below: if the namespaced form
+  //    `compound-engineering:<category>:<agent>` were rewritten first, the
+  //    Task regex would no longer recognize the line because the agent name
+  //    would already be a markdown link.
+  out = out.replace(
+    /(^|\n)(\s*-?\s*)Task\s+([a-z][a-z0-9:-]*)\(([^)]*)\)/g,
+    (_match, lead: string, prefix: string, agentName: string, args: string) => {
+      const finalSegment = agentName.includes(":")
+        ? agentName.split(":").pop()!
+        : agentName
+      const trimmed = args.trim()
+      const directive = trimmed
+        ? `Adopt the persona in ${warpAgentLink(finalSegment)} and: ${trimmed}`
+        : `Adopt the persona in ${warpAgentLink(finalSegment)}`
+      return `${lead}${prefix}${directive}`
+    },
+  )
+
+  // 5. Fully-qualified agent references:
+  //    `compound-engineering:<category>:<agent-name>` →
+  //    a markdown link to the colocated persona file. Catches in-prose and
+  //    table-cell references that didn't go through a Task dispatch.
+  out = out.replace(
+    /compound-engineering:[a-z][a-z0-9-]*:([a-z][a-z0-9-]*)/g,
+    (_match, agentName: string) => warpAgentLink(agentName),
+  )
+
+  // 6. Bare `@agent-suffix` references (security-sentinel, performance-oracle,
+  //    *-reviewer, *-researcher, etc.) that are not already inside a markdown
+  //    link. Same suffix list as the Gemini converter so we catch the same
+  //    set of agent names without false positives on `@username`-style
+  //    mentions in prose.
+  const bareAgentRef = /(?<!\]\()@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))\b/gi
+  out = out.replace(bareAgentRef, (_match, agentName: string) => {
+    return warpAgentLink(agentName)
+  })
+
+  return out
+}
+
+/**
+ * Render a markdown link to the persona file for `agentName`. Centralizing
+ * this keeps the relative-path layout in one place; if v0.2 moves agents
+ * elsewhere or replaces them with `/orchestrate` calls, only this function
+ * changes.
+ */
+export function warpAgentLink(agentName: string): string {
+  return `[${agentName}](${WARP_AGENTS_RELATIVE_DIR}/${agentName}.md)`
+}
+
+/**
+ * Apply `transform` to every chunk of `input` that lives outside a fenced
+ * markdown code block. Fences are detected by a leading run of backticks at
+ * the start of a line (same heuristic CommonMark uses for fenced code); we
+ * deliberately don't try to support arbitrary indentation because skill
+ * content authored in this plugin always starts fences at column zero.
+ */
+function rewriteOutsideFencedBlocks(input: string, transform: (chunk: string) => string): string {
+  const fenceRegex = /^(`{3,}|~{3,})/m
+  let out = ""
+  let remaining = input
+  let inFence = false
+  let fenceMarker = ""
+  while (remaining.length > 0) {
+    if (!inFence) {
+      const match = remaining.match(fenceRegex)
+      if (!match || match.index === undefined) {
+        out += transform(remaining)
+        break
+      }
+      out += transform(remaining.slice(0, match.index))
+      fenceMarker = match[1]
+      inFence = true
+      // Include the opening fence line verbatim.
+      const newlineIdx = remaining.indexOf("\n", match.index)
+      const fenceLineEnd = newlineIdx === -1 ? remaining.length : newlineIdx + 1
+      out += remaining.slice(match.index, fenceLineEnd)
+      remaining = remaining.slice(fenceLineEnd)
+      continue
+    }
+    // Inside a fence — find the matching closing fence at column zero.
+    const closingPattern = new RegExp(`^${fenceMarker}\\s*$`, "m")
+    const close = remaining.match(closingPattern)
+    if (!close || close.index === undefined) {
+      // Unterminated fence — emit the rest verbatim.
+      out += remaining
+      break
+    }
+    const newlineIdx = remaining.indexOf("\n", close.index)
+    const closeEnd = newlineIdx === -1 ? remaining.length : newlineIdx + 1
+    out += remaining.slice(0, closeEnd)
+    remaining = remaining.slice(closeEnd)
+    inFence = false
+    fenceMarker = ""
+  }
+  return out
+}

--- a/tests/detect-tools.test.ts
+++ b/tests/detect-tools.test.ts
@@ -45,7 +45,10 @@ describe("detectInstalledTools", () => {
 
     const results = await detectInstalledTools(tempHome, tempCwd)
 
-    expect(results.length).toBe(8)
+    // Detection set: opencode, codex, pi, droid, copilot, gemini, kiro, qwen, warp.
+    // Bumping this number is the canonical signal that a new target was added
+    // and should be considered for the install/cleanup/convert command surfaces.
+    expect(results.length).toBe(9)
     for (const tool of results) {
       expect(tool.detected).toBe(false)
       expect(tool.reason).toBe("not found")

--- a/tests/warp-converter.test.ts
+++ b/tests/warp-converter.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test"
+import { convertClaudeToWarp } from "../src/converters/claude-to-warp"
+import type { ClaudePlugin } from "../src/types/claude"
+
+const fixturePlugin: ClaudePlugin = {
+  root: "/tmp/plugin",
+  manifest: { name: "fixture", version: "1.0.0" },
+  agents: [
+    {
+      name: "security-sentinel",
+      description: "Performs security audits and OWASP-aligned vulnerability assessments.",
+      model: "inherit",
+      body: "You are an Application Security Specialist. Focus on vulnerabilities first.",
+      sourcePath: "/tmp/plugin/agents/review/security-sentinel.md",
+    },
+    {
+      name: "code-simplicity-reviewer",
+      body: "Final pass for simplicity and minimalism.",
+      sourcePath: "/tmp/plugin/agents/review/code-simplicity-reviewer.md",
+    },
+  ],
+  commands: [],
+  skills: [
+    {
+      name: "ce-plan",
+      description: "Planning skill",
+      sourceDir: "/tmp/plugin/skills/ce-plan",
+      skillPath: "/tmp/plugin/skills/ce-plan/SKILL.md",
+    },
+    {
+      name: "claude-only",
+      description: "Skill that only ships on Claude Code",
+      ce_platforms: ["claude"],
+      sourceDir: "/tmp/plugin/skills/claude-only",
+      skillPath: "/tmp/plugin/skills/claude-only/SKILL.md",
+    },
+  ],
+  hooks: undefined,
+  mcpServers: {
+    "agent-browser": { command: "agent-browser", args: ["server"] },
+    "untracked-server": { command: "echo" },
+  },
+}
+
+const baseOptions = {
+  agentMode: "subagent" as const,
+  inferTemperature: true,
+  permissions: "none" as const,
+  codexIncludeSkills: false,
+}
+
+describe("convertClaudeToWarp", () => {
+  test("filters out skills not flagged for warp", () => {
+    const bundle = convertClaudeToWarp(fixturePlugin, baseOptions)
+    expect(bundle.skillDirs.map((s) => s.name)).toEqual(["ce-plan"])
+  })
+
+  test("lowers each agent into a frontmatter-stripped persona file", () => {
+    const bundle = convertClaudeToWarp(fixturePlugin, baseOptions)
+    expect(bundle.agents).toHaveLength(2)
+    const sentinel = bundle.agents.find((a) => a.name === "security-sentinel")
+    expect(sentinel).toBeDefined()
+    // No YAML frontmatter on the lowered file — the file is read by the
+    // dispatching skill at runtime, not loaded by Warp's skill discovery.
+    expect(sentinel!.content.startsWith("---")).toBe(false)
+    // The synthesized intro names the persona and includes the description.
+    expect(sentinel!.content).toContain("# Persona: security-sentinel")
+    expect(sentinel!.content).toContain("Performs security audits")
+    // Original body is preserved.
+    expect(sentinel!.content).toContain("Application Security Specialist")
+  })
+
+  test("agent without description still gets a heading-only intro", () => {
+    const bundle = convertClaudeToWarp(fixturePlugin, baseOptions)
+    const reviewer = bundle.agents.find((a) => a.name === "code-simplicity-reviewer")
+    expect(reviewer).toBeDefined()
+    expect(reviewer!.content).toContain("# Persona: code-simplicity-reviewer")
+    expect(reviewer!.content).toContain("Final pass for simplicity and minimalism.")
+  })
+
+  test("declared MCP servers are preserved in postinstall hint order", () => {
+    const bundle = convertClaudeToWarp(fixturePlugin, baseOptions)
+    // Recommended-list servers come first when present, then everything else
+    // declared by the manifest, deduped.
+    expect(bundle.recommendedMcpServers).toContain("agent-browser")
+    expect(bundle.recommendedMcpServers).toContain("untracked-server")
+  })
+
+  test("falls back to the recommended list when the plugin declares no MCP servers", () => {
+    const plugin: ClaudePlugin = { ...fixturePlugin, mcpServers: undefined }
+    const bundle = convertClaudeToWarp(plugin, baseOptions)
+    expect(bundle.recommendedMcpServers.length).toBeGreaterThan(0)
+    // The bundled recommended list lives in the converter; it always
+    // includes agent-browser, which is the most user-visible recommendation.
+    expect(bundle.recommendedMcpServers).toContain("agent-browser")
+  })
+
+  test("AGENTS.md snippet describes the canonical compound-engineering layout", () => {
+    const bundle = convertClaudeToWarp(fixturePlugin, baseOptions)
+    expect(bundle.project.agentsMd).toBeDefined()
+    const snippet = bundle.project.agentsMd!
+    // Sanity-check that the snippet links to the install repo and names the
+    // canonical artifact directories. If these strings drift we want the
+    // test to fail so the AGENTS.md contract stays explicit.
+    expect(snippet).toContain("compound-engineering")
+    expect(snippet).toContain("docs/brainstorms/")
+    expect(snippet).toContain("docs/plans/")
+    expect(snippet).toContain("docs/solutions/")
+    expect(snippet).toContain("/ce-brainstorm")
+    expect(snippet).toContain("/ce-plan")
+  })
+
+  test("collisions in sanitized agent names produce a warning, not duplicates", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [
+        { name: "ce:plan", body: "First", sourcePath: "/tmp/plugin/agents/a.md" },
+        { name: "ce-plan", body: "Second", sourcePath: "/tmp/plugin/agents/b.md" },
+      ],
+    }
+    const originalWarn = console.warn
+    const warnings: string[] = []
+    console.warn = (msg: string) => warnings.push(msg)
+    try {
+      const bundle = convertClaudeToWarp(plugin, baseOptions)
+      expect(bundle.agents).toHaveLength(1)
+      expect(bundle.agents[0].name).toBe("ce-plan")
+      // Both ce:plan and ce-plan sanitize to the same on-disk filename, so
+      // the second one is dropped with a warning.
+      expect(warnings.some((w) => w.includes("collides"))).toBe(true)
+    } finally {
+      console.warn = originalWarn
+    }
+  })
+})

--- a/tests/warp-rewrites.test.ts
+++ b/tests/warp-rewrites.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test"
+import {
+  WARP_AGENTS_MD_BEGIN,
+  WARP_AGENTS_MD_END,
+  WARP_AGENTS_RELATIVE_DIR,
+  transformContentForWarp,
+  warpAgentLink,
+} from "../src/utils/warp-rewrites"
+
+describe("transformContentForWarp", () => {
+  test("rewrites CLAUDE.md prose mentions to AGENTS.md", () => {
+    const result = transformContentForWarp(
+      "Project conventions live in CLAUDE.md. Read CLAUDE.md before editing.",
+    )
+    expect(result).toContain("AGENTS.md")
+    expect(result).not.toContain("CLAUDE.md")
+  })
+
+  test("preserves CLAUDE.md inside fenced code blocks", () => {
+    const input = [
+      "Outside the fence: CLAUDE.md",
+      "```",
+      "# Inside fenced block",
+      "// Reference to CLAUDE.md preserved verbatim",
+      "```",
+      "After the fence: CLAUDE.md again",
+    ].join("\n")
+
+    const result = transformContentForWarp(input)
+    // Outside-the-fence references rewritten.
+    expect(result).toContain("Outside the fence: AGENTS.md")
+    expect(result).toContain("After the fence: AGENTS.md again")
+    // Inside-the-fence reference preserved.
+    expect(result).toContain("// Reference to CLAUDE.md preserved verbatim")
+  })
+
+  test("rewrites .claude/ paths but leaves .claude-plugin/ untouched", () => {
+    const result = transformContentForWarp(
+      "Skills live under ~/.claude/skills/ and .claude/skills/. Manifest stays at .claude-plugin/plugin.json.",
+    )
+    expect(result).toContain("~/.warp/skills/")
+    expect(result).toContain(".warp/skills/")
+    expect(result).toContain(".claude-plugin/plugin.json")
+    expect(result).not.toContain("~/.claude/skills/")
+    expect(result).not.toContain(" .claude/skills/")
+  })
+
+  test("collapses the multi-platform Interaction Method preamble", () => {
+    const input = [
+      "## Interaction Method",
+      "",
+      "When asking the user a question, use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.",
+      "",
+      "Ask one question at a time. Prefer a concise single-select choice when natural options exist.",
+    ].join("\n")
+    const result = transformContentForWarp(input)
+    // The platform-specific tool names must be gone.
+    expect(result).not.toContain("AskUserQuestion")
+    expect(result).not.toContain("request_user_input")
+    expect(result).not.toContain("ask_user")
+    expect(result).not.toContain("ToolSearch")
+    // The Warp-friendly replacement is in.
+    expect(result).toContain("ask one focused question at a time")
+    expect(result).toContain("Warp surfaces blocking prompts natively")
+  })
+
+  test("rewrites fully-qualified compound-engineering agent references to persona links", () => {
+    const result = transformContentForWarp(
+      "| `compound-engineering:review:security-sentinel` | Security review |",
+    )
+    expect(result).toContain(warpAgentLink("security-sentinel"))
+    expect(result).not.toContain("compound-engineering:review:security-sentinel")
+    // Sanity check: the link points at the colocated persona file.
+    expect(result).toContain(`${WARP_AGENTS_RELATIVE_DIR}/security-sentinel.md`)
+  })
+
+  test("collapses Task <agent>(args) dispatch lines into adopt-the-persona directives", () => {
+    const input = [
+      "- Task security-sentinel(scan auth middleware)",
+      "- Task compound-engineering:research:repo-research-analyst(feature_description)",
+      "- Task code-simplicity-reviewer()",
+    ].join("\n")
+
+    const result = transformContentForWarp(input)
+    expect(result).toContain(`Adopt the persona in ${warpAgentLink("security-sentinel")} and: scan auth middleware`)
+    expect(result).toContain(`Adopt the persona in ${warpAgentLink("repo-research-analyst")} and: feature_description`)
+    expect(result).toContain(`Adopt the persona in ${warpAgentLink("code-simplicity-reviewer")}`)
+    expect(result).not.toContain("Task security-sentinel(")
+    expect(result).not.toContain("Task compound-engineering:")
+    expect(result).not.toContain("Task code-simplicity-reviewer(")
+  })
+
+  test("rewrites bare @<agent>-suffix references but leaves arbitrary @mentions alone", () => {
+    const input = [
+      "Spawn @security-sentinel and @performance-oracle.",
+      "Mention @user-name in passing.",
+    ].join("\n")
+
+    const result = transformContentForWarp(input)
+    expect(result).toContain(warpAgentLink("security-sentinel"))
+    expect(result).toContain(warpAgentLink("performance-oracle"))
+    // Non-agent @-mentions are left untouched.
+    expect(result).toContain("@user-name")
+  })
+
+  test("AGENTS.md merge marker constants are stable strings", () => {
+    // These strings get embedded in user AGENTS.md files; if they change in a
+    // patch release, existing installs won't be able to find their managed
+    // block. Lock them to the exact bytes the writer relies on.
+    expect(WARP_AGENTS_MD_BEGIN).toBe("<!-- compound-engineering:begin -->")
+    expect(WARP_AGENTS_MD_END).toBe("<!-- compound-engineering:end -->")
+  })
+})

--- a/tests/warp-writer.test.ts
+++ b/tests/warp-writer.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import path from "path"
+import os from "os"
+import { writeWarpBundle } from "../src/targets/warp"
+import {
+  WARP_AGENTS_MD_BEGIN,
+  WARP_AGENTS_MD_END,
+} from "../src/utils/warp-rewrites"
+import type { WarpBundle } from "../src/types/warp"
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function makeSourceSkill(parent: string, name: string, body: string): Promise<string> {
+  const dir = path.join(parent, name)
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(path.join(dir, "SKILL.md"), body)
+  return dir
+}
+
+describe("writeWarpBundle", () => {
+  test("writes skills, agents, and AGENTS.md at the workspace root", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "warp-write-"))
+    const sourceParent = await fs.mkdtemp(path.join(os.tmpdir(), "warp-source-"))
+    const skillDir = await makeSourceSkill(
+      sourceParent,
+      "ce-plan",
+      `---
+name: ce-plan
+description: Planning skill
+---
+
+Read CLAUDE.md before editing. Use \`compound-engineering:review:security-sentinel\` for security review.
+`,
+    )
+
+    const bundle: WarpBundle = {
+      pluginName: "compound-engineering",
+      skillDirs: [{ name: "ce-plan", sourceDir: skillDir }],
+      agents: [
+        { name: "security-sentinel", content: "# Persona: security-sentinel\n\nReview for vulnerabilities.\n" },
+      ],
+      project: { agentsMd: "## Compound Engineering\n\nCustom snippet for tests." },
+      recommendedMcpServers: ["agent-browser"],
+    }
+
+    await writeWarpBundle(tempRoot, bundle)
+
+    // Filesystem layout.
+    expect(await exists(path.join(tempRoot, ".warp", "skills", "ce-plan", "SKILL.md"))).toBe(true)
+    expect(await exists(path.join(tempRoot, ".warp", "skills", "_ce-agents", "security-sentinel.md"))).toBe(true)
+    expect(await exists(path.join(tempRoot, ".warp", "compound-engineering", "install-manifest.json"))).toBe(true)
+    expect(await exists(path.join(tempRoot, "AGENTS.md"))).toBe(true)
+
+    // SKILL.md content was rewritten on copy.
+    const installedSkill = await fs.readFile(
+      path.join(tempRoot, ".warp", "skills", "ce-plan", "SKILL.md"),
+      "utf8",
+    )
+    expect(installedSkill).toContain("Read AGENTS.md before editing")
+    expect(installedSkill).toContain("../_ce-agents/security-sentinel.md")
+    expect(installedSkill).not.toContain("compound-engineering:review:security-sentinel")
+    expect(installedSkill).not.toContain("CLAUDE.md")
+
+    // Agent persona file is written verbatim.
+    const persona = await fs.readFile(
+      path.join(tempRoot, ".warp", "skills", "_ce-agents", "security-sentinel.md"),
+      "utf8",
+    )
+    expect(persona).toContain("Review for vulnerabilities.")
+
+    // AGENTS.md is fenced with the managed-block markers.
+    const agentsMd = await fs.readFile(path.join(tempRoot, "AGENTS.md"), "utf8")
+    expect(agentsMd).toContain(WARP_AGENTS_MD_BEGIN)
+    expect(agentsMd).toContain(WARP_AGENTS_MD_END)
+    expect(agentsMd).toContain("Custom snippet for tests.")
+  })
+
+  test("merges into an existing AGENTS.md without an existing managed block", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "warp-merge-"))
+    const existing = "# My project\n\nUser-authored notes.\n"
+    await fs.writeFile(path.join(tempRoot, "AGENTS.md"), existing)
+
+    const bundle: WarpBundle = {
+      pluginName: "compound-engineering",
+      skillDirs: [],
+      agents: [],
+      project: { agentsMd: "## Compound Engineering\n\nManaged content." },
+      recommendedMcpServers: [],
+    }
+
+    await writeWarpBundle(tempRoot, bundle)
+
+    const merged = await fs.readFile(path.join(tempRoot, "AGENTS.md"), "utf8")
+    expect(merged).toContain("User-authored notes.")
+    expect(merged).toContain(WARP_AGENTS_MD_BEGIN)
+    expect(merged).toContain("Managed content.")
+    // The user's content stays before the managed block.
+    expect(merged.indexOf("User-authored notes.")).toBeLessThan(merged.indexOf(WARP_AGENTS_MD_BEGIN))
+
+    // Backup of the original was made.
+    const entries = await fs.readdir(tempRoot)
+    expect(entries.some((e) => e.startsWith("AGENTS.md.bak."))).toBe(true)
+  })
+
+  test("replaces an existing managed block in AGENTS.md surgically", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "warp-replace-"))
+    const existing = [
+      "# My project",
+      "",
+      "Before block.",
+      "",
+      WARP_AGENTS_MD_BEGIN,
+      "## Compound Engineering",
+      "",
+      "Old managed snippet.",
+      WARP_AGENTS_MD_END,
+      "",
+      "After block.",
+      "",
+    ].join("\n")
+    await fs.writeFile(path.join(tempRoot, "AGENTS.md"), existing)
+
+    const bundle: WarpBundle = {
+      pluginName: "compound-engineering",
+      skillDirs: [],
+      agents: [],
+      project: { agentsMd: "## Compound Engineering\n\nNew managed snippet." },
+      recommendedMcpServers: [],
+    }
+
+    await writeWarpBundle(tempRoot, bundle)
+
+    const merged = await fs.readFile(path.join(tempRoot, "AGENTS.md"), "utf8")
+    expect(merged).toContain("Before block.")
+    expect(merged).toContain("After block.")
+    expect(merged).toContain("New managed snippet.")
+    expect(merged).not.toContain("Old managed snippet.")
+  })
+
+  test("global install (~/.warp) skips AGENTS.md merge", async () => {
+    // Simulate a global install by passing an outputRoot whose parent is the
+    // current process's HOME. The writer infers global vs workspace from the
+    // env-derived HOME.
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "warp-home-"))
+    const originalHome = process.env.HOME
+    process.env.HOME = tempHome
+    try {
+      const warpRoot = path.join(tempHome, ".warp")
+      const bundle: WarpBundle = {
+        pluginName: "compound-engineering",
+        skillDirs: [],
+        agents: [],
+        project: { agentsMd: "## Compound Engineering\n\nShould not appear in $HOME/AGENTS.md." },
+        recommendedMcpServers: [],
+      }
+
+      await writeWarpBundle(warpRoot, bundle)
+
+      // Files land under ~/.warp/skills/ regardless.
+      expect(await exists(path.join(warpRoot, "skills"))).toBe(true)
+      // ~/AGENTS.md is NOT touched.
+      expect(await exists(path.join(tempHome, "AGENTS.md"))).toBe(false)
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+    }
+  })
+
+  test("reinstall removes skills and agents that disappeared from the bundle", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "warp-upgrade-"))
+    const sourceParent = await fs.mkdtemp(path.join(os.tmpdir(), "warp-upgrade-source-"))
+    const skillA = await makeSourceSkill(sourceParent, "ce-plan", `---\nname: ce-plan\n---\nA`)
+    const skillB = await makeSourceSkill(sourceParent, "ce-old", `---\nname: ce-old\n---\nB`)
+
+    // First install: both skills present, two agents.
+    await writeWarpBundle(tempRoot, {
+      pluginName: "compound-engineering",
+      skillDirs: [
+        { name: "ce-plan", sourceDir: skillA },
+        { name: "ce-old", sourceDir: skillB },
+      ],
+      agents: [
+        { name: "security-sentinel", content: "# Persona: security-sentinel\n" },
+        { name: "old-reviewer", content: "# Persona: old-reviewer\n" },
+      ],
+      project: { agentsMd: "## Compound Engineering" },
+      recommendedMcpServers: [],
+    })
+
+    expect(await exists(path.join(tempRoot, ".warp", "skills", "ce-old", "SKILL.md"))).toBe(true)
+    expect(await exists(path.join(tempRoot, ".warp", "skills", "_ce-agents", "old-reviewer.md"))).toBe(true)
+
+    // Second install: ce-old and old-reviewer removed.
+    await writeWarpBundle(tempRoot, {
+      pluginName: "compound-engineering",
+      skillDirs: [{ name: "ce-plan", sourceDir: skillA }],
+      agents: [{ name: "security-sentinel", content: "# Persona: security-sentinel\n" }],
+      project: { agentsMd: "## Compound Engineering" },
+      recommendedMcpServers: [],
+    })
+
+    expect(await exists(path.join(tempRoot, ".warp", "skills", "ce-plan", "SKILL.md"))).toBe(true)
+    expect(await exists(path.join(tempRoot, ".warp", "skills", "ce-old"))).toBe(false)
+    expect(await exists(path.join(tempRoot, ".warp", "skills", "_ce-agents", "security-sentinel.md"))).toBe(true)
+    expect(await exists(path.join(tempRoot, ".warp", "skills", "_ce-agents", "old-reviewer.md"))).toBe(false)
+  })
+
+  test("does not double-nest when output root is already .warp", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "warp-nest-"))
+    const warpRoot = path.join(tempRoot, ".warp")
+    const sourceParent = await fs.mkdtemp(path.join(os.tmpdir(), "warp-nest-source-"))
+    const skill = await makeSourceSkill(sourceParent, "ce-plan", `---\nname: ce-plan\n---\nbody`)
+
+    await writeWarpBundle(warpRoot, {
+      pluginName: "compound-engineering",
+      skillDirs: [{ name: "ce-plan", sourceDir: skill }],
+      agents: [],
+      project: { agentsMd: "## Compound Engineering" },
+      recommendedMcpServers: [],
+    })
+
+    expect(await exists(path.join(warpRoot, "skills", "ce-plan", "SKILL.md"))).toBe(true)
+    expect(await exists(path.join(warpRoot, ".warp"))).toBe(false)
+  })
+})


### PR DESCRIPTION
Adds `--to warp` as a first-class install target. See docs/warp.md for the design.